### PR TITLE
Write a test for Env::Global

### DIFF
--- a/test/binding.cc
+++ b/test/binding.cc
@@ -59,6 +59,7 @@ Object InitObjectReference(Env env);
 Object InitReference(Env env);
 Object InitVersionManagement(Env env);
 Object InitThunkingManual(Env env);
+Object InitEnv(Env env);
 
 Object Init(Env env, Object exports) {
 #if (NAPI_VERSION > 5)
@@ -120,6 +121,7 @@ Object Init(Env env, Object exports) {
   exports.Set("reference", InitReference(env));
   exports.Set("version_management", InitVersionManagement(env));
   exports.Set("thunking_manual", InitThunkingManual(env));
+  exports.Set("env", InitEnv(env));
   return exports;
 }
 

--- a/test/binding.gyp
+++ b/test/binding.gyp
@@ -22,6 +22,7 @@
         'dataview/dataview.cc',
         'dataview/dataview_read_write.cc',
         'error.cc',
+        'env.cc',
         'external.cc',
         'function.cc',
         'handlescope.cc',

--- a/test/env.cc
+++ b/test/env.cc
@@ -1,0 +1,19 @@
+#include "napi.h"
+
+namespace {
+Napi::Value HasSetImmediate(const Napi::CallbackInfo& info) {
+  return Napi::Boolean::New(info.Env(),
+                            info.Env().Global().Has("setImmediate"));
+}
+Napi::Value HasRequire(const Napi::CallbackInfo& info) {
+  return Napi::Boolean::New(info.Env(), info.Env().Global().Has("require"));
+}
+}  // namespace
+
+Napi::Object InitEnv(Napi::Env env) {
+  Napi::Object exports = Napi::Object::New(env);
+  exports["HasSetImmediate"] = Napi::Function::New(env, HasSetImmediate);
+  exports["HasRequire"] = Napi::Function::New(env, HasRequire);
+
+  return exports;
+}

--- a/test/env.js
+++ b/test/env.js
@@ -1,0 +1,11 @@
+"use strict";
+const assert = require("assert");
+const buildType = process.config.target_defaults.default_configuration;
+
+test(require(`./build/${buildType}/binding.node`));
+test(require(`./build/${buildType}/binding_noexcept.node`));
+
+function test(binding) {
+  assert.strictEqual(binding.env.HasSetImmediate(), true);
+  assert.strictEqual(binding.env.HasRequire(), false);
+}

--- a/test/index.js
+++ b/test/index.js
@@ -28,6 +28,7 @@ let testModules = [
   'callbackscope',
   'dataview/dataview',
   'dataview/dataview_read_write',
+  'env',
   'error',
   'external',
   'function',


### PR DESCRIPTION
Instructions for writing tests for `Env::Global`:
1. Get local copy and set upstream
2. Follow testing and debugging instructions from https://github.com/nodejs/node-addon-api
3. Add `env.cc` and `env.js` files under `test` folder
4. Add `'env'` to `testModules` in `test/index.js`
5. Add `'env.cc'` to `sources` in `test/binding.gyp`
6. Add `Object InitEnv(Env env);` to declarations and `exports.Set("env", InitEnv(env));` to `test/binding.cc`
7. In your `env.cc`, implement `InitEnv`
8. In your `env.js`, be sure to include the following lines at the top of the file:
```
const buildType = process.config.target_defaults.default_configuration;

test(require(`./build/${buildType}/binding.node`));
test(require(`./build/${buildType}/binding_noexcept.node`));
```
The function definition of `Env::Global` can be found in `napi-inl.h`. To learn more about the object returned by calling `Global`, see this documentation: https://nodejs.org/api/globals.html#globals_global. Looking at other test files will help you accomplish this task.